### PR TITLE
Configure Vercel output directory

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "buildCommand": "npm run build",
+  "outputDirectory": ".next"
+}


### PR DESCRIPTION
## Summary
- add a vercel.json configuration so the build artifact directory points to the Next.js `.next` folder
- ensure Vercel uses the standard build command so deployments succeed

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d7f06d1180832bb9124b002de07453